### PR TITLE
Chapter 12. Password Reset

### DIFF
--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -16,6 +16,8 @@ class AccountActivationsController < ApplicationController
   private
   def find_user
     @user = User.find_by email: params[:email]
-    redirect_to root_path, flash: {warning: t("users.index.error")} if @user.nil?
+    return if @user.present?
+
+    redirect_to root_path, flash: {warning: t("users.index.error")}
   end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,68 @@
+class PasswordResetsController < ApplicationController
+  before_action :find_user, only: %i(create)
+  before_action :get_user, :valid_user, :check_expiration, only: %i(edit update)
+
+  def new; end
+
+  def create
+    @user.create_reset_digest
+    @user.send_password_reset_email
+    flash[:info] = t("password_resets.new.sent_request")
+    redirect_to root_path
+  end
+
+  def edit; end
+
+  def update
+    if params[:user][:password].empty? ||
+       params[:user][:password_confirmation].empty?
+      @user.errors.add(:password)
+      render :edit, status: :unprocessable_entity
+    elsif @user.update(user_params)
+      reset_session
+      login @user
+      @user.update_column :reset_digest, nil
+      flash[:success] = t(".success")
+      redirect_to @user
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
+
+  def find_user
+    @user = User.find_by email: params[:password_reset][:email].downcase
+    return if @user.present?
+
+    flash.now[:danger] = t("users.index.error")
+    render :new, status: :unprocessable_entity
+  end
+
+  def get_user
+    @user = User.find_by email: params[:email]
+    return if @user.present?
+
+    redirect_to root_path,
+                flash: {warning: t("users.index.error")}
+  end
+
+  # Confirms a valid user.
+  def valid_user
+    return if @user&.activated? &&
+              @user&.authenticated?(:reset, params[:id])
+    redirect_to root_path, flash: {warning: t("users.index.error")}
+  end
+
+  # Checks expiration of reset token.
+  def check_expiration
+    return unless @user.password_reset_expired?
+
+    flash[:danger] = t(".request_expired")
+    redirect_to new_password_reset_path
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,4 @@
 class UserMailer < ApplicationMailer
-
   # Subject can be set in your I18n file at config/locales/en.yml
   # with the following lookup:
   #
@@ -15,4 +14,8 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.password_reset.subject
   #
+  def password_reset user
+    @user = user
+    mail to: user.email, subject: t("user_mailer.password_resets.subject")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
 
   before_create :create_activation_digest
   before_save :downcase_email
@@ -61,6 +61,23 @@ class User < ApplicationRecord
   # Activates an account.
   def activate
     update_columns activated: true, activated_at: Time.zone.now
+  end
+
+  # Sets the password reset attributes.
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_columns reset_digest: User.digest(reset_token),
+                   reset_sent_at: Time.zone.now
+  end
+
+  # Sends password reset email.
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
+  end
+
+  # Returns true if a password reset has expired.
+  def password_reset_expired?
+    reset_sent_at < 2.hours.ago
   end
 
   private

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,20 @@
+<% provide(:title, t(".title")) %>
+<h1><%= t(".title") %></h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(model: @user, url: password_reset_path(params[:id])) do |f| %>
+      <%= render "shared/error_messages" %>
+
+      <%= hidden_field_tag :email, @user.email %>
+
+      <%= f.label t(".password") %>
+      <%= f.password_field :password, class: "form-control" %>
+
+      <%= f.label t(".password_confirmation") %>
+      <%= f.password_field :password_confirmation, class: "form-control" %>
+
+      <%= f.submit t(".submit"), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,13 @@
+<% provide(:title, t(".title")) %>
+<h1><%= t(".title") %></h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(url: password_resets_path, scope: :password_reset) do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: "form-control" %>
+
+      <%= f.submit t(".submit"), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,6 +9,7 @@
       <%= f.email_field :email, class: "form-control" %>
 
       <%= f.label :password, t(".password") %>
+      <%= link_to t(".forgot_password"), new_password_reset_path %>
       <%= f.password_field :password, class: "form-control" %>
 
       <%= f.label :remember_me, t(".remember_me"), class: "checkbox inline" do %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,8 @@
+<h1><%= t(".subject") %></h1>
+
+<p><%= t(".title") %></p>
+
+<%= link_to "Reset password", edit_password_reset_url(id: @user.reset_token,
+                                                      email: @user.email) %>
+
+<p><%= t(".description") %></p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,3 +1,4 @@
-User#password_reset
+<%= t(".subject") %>
+<%= edit_password_reset_url(id: @user.reset_token, email: @user.email) %>
 
-<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb
+<%= t(".description") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,15 +63,33 @@ en:
       activate: "Activate"
       success: "Account activated!"
       fail: "Invalid activation link"
+    password_reset:
+      subject: "Password reset"
+      title: "To reset your password click the link below:"
+      description: "This link will expire in two hours.\nIf you did not request your password to be reset, please ignore this email and your password will stay as it is."
   sessions:
     new:
       login: "Login"
       password: "Password"
+      forgot_password: "Forgot password?"
       new_user_title: "New user?"
       sign_up_title: "Create new user!"
       remember_me: "Remember me"
     create:
       not_activated: "Account not activated. Check your email for activation link."
       error: "Invalid email/password combination"
+  password_resets:
+    new:
+      title: "Forgot password"
+      submit: "Submit"
+      sent_request: "Email sent with password reset instructions"
+    edit:
+      title: "Forgot password"
+      submit: "Submit"
+      password: "Password"
+      password_confirmation: "Password confirmation"
+    update:
+      success: "Password has been reset."
+      request_expired: "Password reset has expired."
   error:
     form_error_count: "The form has total of errors"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -63,15 +63,33 @@ vi:
       activate: "Kích hoạt"
       success: "Tài khoản được kích hoạt!"
       fail: "Link kích hoạt không hợp lệ"
+    password_reset:
+      subject: "Đặt lại mật khẩu"
+      title: "Để đặt lại mật khẩu của bạn hãy nhấp vào liên kết bên dưới:"
+      description: "Liên kết này sẽ hết hạn sau hai giờ.\nNếu bạn không yêu cầu đặt lại mật khẩu của mình, vui lòng bỏ qua email này và mật khẩu của bạn sẽ vẫn như cũ."
   sessions:
     new:
       login: "Đăng nhập"
       password: "Mật khẩu"
+      forgot_password: "Quên mật khẩu?"
       new_user_title: "Chưa có tài khoản?"
       sign_up_title: "Tạo tài khoản ngay!"
       remember_me: "Ghi nhớ đăng nhập"
     create:
       not_activated: "Tài khoản chưa được kích hoạt. Hãy kiểm tra email của bạn để lấy liên kết kích hoạt."
       error: "Email/mật khẩu không hợp lệ"
+  password_resets:
+    new:
+      title: "Quên mật khẩu"
+      submit: "Gửi"
+      sent_request: "Email được gửi cùng với hướng dẫn đặt lại mật khẩu"
+    edit:
+      title: "Quên mật khẩu"
+      submit: "Gửi"
+      password: "Mật khẩu"
+      password_confirmation: "Xác nhận mật khẩu"
+    update:
+      success: "Mật khẩu đã được cập nhật."
+      request_expired: "Yêu cầu thay đổi mật khẩu đã hết hạn."
   error:
     form_error_count: "Form gồm số lỗi"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,6 @@ Rails.application.routes.draw do
 
     resources :users
     resources :account_activations, only: [:edit]
+    resources :password_resets,     only: [:new, :create, :edit, :update]
   end
 end

--- a/db/migrate/20230823071542_add_reset_to_users.rb
+++ b/db/migrate/20230823071542_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_23_042531) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_23_071542) do
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -22,6 +22,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_23_042531) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## Chapter 12. Password Reset

1. **destroy:**
   - `destroy` là một phương thức được cung cấp bởi Rails, và nó thực hiện nhiều tác vụ hơn so với việc xóa một bản ghi. Khi gọi `destroy` trên một đối tượng, Rails sẽ:
     - Gọi các callbacks trước khi xóa (trước khi destroy).
     - Xóa đối tượng khỏi cơ sở dữ liệu.
     - Gọi các callbacks sau khi xóa (sau khi destroy).
   - Các quan hệ liên quan (associations) cũng có thể được xử lý thông qua các tùy chọn như `dependent: :destroy` để tự động xóa các quan hệ liên quan khi đối tượng chính bị xóa.

2. **delete:**
   - `delete` cũng là một phương thức được cung cấp bởi Rails, nhưng nó chỉ đơn giản là xóa bản ghi từ cơ sở dữ liệu mà không thực hiện bất kỳ callback nào.
   - `delete` không thực hiện callback và không xử lý các quan hệ liên quan.
 3. **Phân biệt các method update trong rails**
 - update_attribute: Cập nhật một thuộc tính cụ thể của một đối tượng và khích hoạt các callback và validation. Không còn được khuyến nghị trong Rails phiên bản mới hơn.
   - update_attributes: Cập nhật nhiều thuộc tính của đối tượng và lưu vào cơ sở dữ liệu. Được thay thế bằng update_columns trong Rails phiên bản mới hơn.
   - update_column: Tương tự update_attribute, nhưng có khả năng cập nhật nhiều cột cùng lúc. Không kích hoạt các callback hoặc validation. Không cập nhật timestamp (created_at, updated_at).
   - update_columns: Cập nhật nhiều cột của đối tượng và lưu vào cơ sở dữ liệu mà không kiểm tra các validation. Thay thế update_attributes trong Rails phiên bản mới hơn.
   - update_attribute!: Cập nhật một thuộc tính cụ thể của một đối tượng và lưu vào cơ sở dữ liệu mà không kiểm tra các validation. Nếu thất bại, nó sẽ ném một ngoại lệ ActiveRecord::ActiveRecordError.
   - update_all: Dùng để cập nhật tất cả các bản ghi thỏa mãn điều kiện cho trường hoặc trường kết hợp. Không kích hoạt các callback hoặc validation.
  
4. **deliver_now:**
   - `deliver_now` được sử dụng để gửi email ngay lập tức khi phương thức `deliver` được gọi. Email sẽ được gửi trong quá trình xử lý request hiện tại.


5. **deliver_later:**
   - `deliver_later` được sử dụng để đặt việc gửi email vào hàng đợi (queue) để gửi sau này. Điều này giúp tránh làm chậm response của request hiện tại.
   - Thay vì gửi email ngay lập tức, email sẽ được đưa vào hàng đợi và gửi sau khi hàng đợi được xử lý bởi worker hoặc background job processor.


